### PR TITLE
Fix for Matcher<View> type mismatch when calling selectListItemByText

### DIFF
--- a/androidtestktx/src/main/java/de/codecentric/androidtestktx/espresso/extensions/Actions.kt
+++ b/androidtestktx/src/main/java/de/codecentric/androidtestktx/espresso/extensions/Actions.kt
@@ -85,7 +85,7 @@ fun Matcher<View>.scrollUp() {
  *
  * @param textMatcher matcher for a specific list item.
  */
-infix fun Matcher<View>.selectListItemByText(textMatcher: () -> Matcher<Any>): ViewInteraction =
+infix fun Matcher<View>.selectListItemByText(textMatcher: () -> Matcher<out Any>): ViewInteraction =
   Espresso.onData(textMatcher()).inAdapterView(this).perform(ViewActions.click())
 
 /**


### PR DESCRIPTION
When trying to use `Actions.selectListItemByText()` with a `Matcher<View>`, the IDE complains about a type mismatch with an expected `Matcher<Any>`, while a `Matcher<View>` is found.
This is because `selectListItemByText()` is expecting a Matcher for the type `Any`, not for a class that extends from `Any`.

![screen shot 2018-11-13 at 9 57 44 am](https://user-images.githubusercontent.com/5433694/48434075-9d18e880-e72d-11e8-8747-d63f555ca013.png)

Adding the `out` keyword fixes that issue.